### PR TITLE
Also handle "rebase-merge" directory.

### DIFF
--- a/lib/close-after-last-tab-with-git.coffee
+++ b/lib/close-after-last-tab-with-git.coffee
@@ -5,5 +5,5 @@ module.exports =
       if atom.workspace.getTextEditors().length is 0
         if atom.project.getDirectories().length is 1
           splitedPath = atom.project.getDirectories()[0].path.split("/")
-          if splitedPath[(splitedPath.length-1)] is ".git"
+          if splitedPath[(splitedPath.length-1)] is ".git" or splitedPath[(splitedPath.length-1)] is "rebase-merge"
             atom.close()


### PR DESCRIPTION
This directory is used when using `git rebase --interactive` so should be similarly closed when the last tab in this window is closed.

Not tested locally; wanted to see if the approach was 🆗 with you first before putting too much time into this. 

Thanks for the useful plugin!
